### PR TITLE
monitor: computer type determination

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -658,14 +658,6 @@ fn is_likely_desktop_system() -> bool {
         }
     }
 
-    // Check CPU power policies, desktops often don't have these
-    let power_saving_exists = Path::new("/sys/module/intel_pstate/parameters/no_hwp").exists()
-        || Path::new("/sys/devices/system/cpu/cpufreq/conservative").exists();
-
-    if !power_saving_exists {
-        return true; // likely a desktop
-    }
-
     // Check battery-specific ACPI paths that laptops typically have
     let laptop_acpi_paths = [
         "/sys/class/power_supply/BAT0",
@@ -677,6 +669,14 @@ fn is_likely_desktop_system() -> bool {
         if Path::new(path).exists() {
             return false; // Likely a laptop
         }
+    }
+
+    // Check CPU power policies, desktops often don't have these
+    let power_saving_exists = Path::new("/sys/module/intel_pstate/parameters/no_hwp").exists()
+        || Path::new("/sys/devices/system/cpu/cpufreq/conservative").exists();
+
+    if !power_saving_exists {
+        return true; // likely a desktop
     }
 
     // Default to assuming desktop if we can't determine

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -648,13 +648,15 @@ fn is_likely_desktop_system() -> bool {
         let chassis_type = chassis_type.trim();
 
         // Chassis types:
+        // https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.8.0.pdf
         // 3=Desktop, 4=Low Profile Desktop, 5=Pizza Box, 6=Mini Tower
         // 7=Tower, 8=Portable, 9=Laptop, 10=Notebook, 11=Hand Held, 13=All In One
         // 14=Sub Notebook, 15=Space-saving, 16=Lunch Box, 17=Main Server Chassis
+        // 31=Convertible Laptop, 24=sealed-case PC
         match chassis_type {
-            "3" | "4" | "5" | "6" | "7" | "15" | "16" | "17" => return true, // desktop form factors
-            "9" | "10" | "14" => return false,                               // laptop form factors
-            _ => {} // Unknown, continue with other checks
+            "3" | "4" | "5" | "6" | "7" | "15" | "16" | "17" | "24" => return true, // desktop form factors
+            "9" | "10" | "14" | "31" => return false, // laptop form factors
+            _ => {}                                   // Unknown, continue with other checks
         }
     }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -652,7 +652,7 @@ fn is_likely_desktop_system() -> bool {
         // 3=Desktop, 4=Low Profile Desktop, 5=Pizza Box, 6=Mini Tower
         // 7=Tower, 8=Portable, 9=Laptop, 10=Notebook, 11=Hand Held, 13=All In One
         // 14=Sub Notebook, 15=Space-saving, 16=Lunch Box, 17=Main Server Chassis
-        // 31=Convertible Laptop, 24=sealed-case PC
+        // 24=sealed-case PC, 31=Convertible Laptop
         match chassis_type {
             "3" | "4" | "5" | "6" | "7" | "15" | "16" | "17" | "24" => return true, // desktop form factors
             "9" | "10" | "14" | "31" => return false, // laptop form factors


### PR DESCRIPTION
I have a LG gram laptop. When I am not connected to AC power it still thinks I am connected to AC power. This is because the is_likely_desktop_system() gets called and decides that my laptop is a desktop. This happens for two main reasons which I have fixed:
- Chassis type 31(the one I have) is not being checked
- It checks power saving profiles before batteries and batteries are an arguably better thing to check as I have never heard of a desktop with a battery