### PR TITLE
cpu: preserve frequency precision and transitions

### DIFF
--- a/watt/config.rs
+++ b/watt/config.rs
@@ -104,12 +104,12 @@ pub struct CpusDelta {
 
   /// Set minimum CPU frequency in MHz.
   ///
-  /// Type: `u64`.
+  /// Type: positive number, in MHz with kHz precision.
   #[serde(skip_serializing_if = "is_default")]
   pub frequency_mhz_minimum: Option<Expression>,
   /// Set maximum CPU frequency in MHz.
   ///
-  /// Type: `u64`.
+  /// Type: positive number, in MHz with kHz precision.
   #[serde(skip_serializing_if = "is_default")]
   pub frequency_mhz_maximum: Option<Expression>,
 
@@ -222,49 +222,16 @@ impl CpusDelta {
         delta.energy_perf_bias = Some(energy_perf_bias);
       }
 
-      if let Some(frequency_mhz_minimum) = &self.frequency_mhz_minimum
-        && let Some(frequency_mhz_minimum) =
-          frequency_mhz_minimum.eval(&state)?
-      {
-        let frequency_mhz_minimum = frequency_mhz_minimum
-          .try_into_number()
-          .context("`cpu.frequency-mhz-minimum` was not a number")?;
-
-        let rounded_value = if frequency_mhz_minimum.fract() != 0.0 {
-          let rounded = frequency_mhz_minimum.round() as u64;
-          log::warn!(
-            "`cpu.frequency-mhz-minimum` yielded a float value \
-             ({frequency_mhz_minimum}), rounding to {rounded}"
-          );
-          rounded
-        } else {
-          frequency_mhz_minimum as u64
-        };
-
-        delta.frequency_mhz_minimum = Some(rounded_value);
-      }
-
-      if let Some(frequency_mhz_maximum) = &self.frequency_mhz_maximum
-        && let Some(frequency_mhz_maximum) =
-          frequency_mhz_maximum.eval(&state)?
-      {
-        let frequency_mhz_maximum = frequency_mhz_maximum
-          .try_into_number()
-          .context("`cpu.frequency-mhz-maximum` was not a number")?;
-
-        let rounded_value = if frequency_mhz_maximum.fract() != 0.0 {
-          let rounded = frequency_mhz_maximum.round() as u64;
-          log::warn!(
-            "`cpu.frequency-mhz-maximum` yielded a float value \
-             ({frequency_mhz_maximum}), rounding to {rounded}"
-          );
-          rounded
-        } else {
-          frequency_mhz_maximum as u64
-        };
-
-        delta.frequency_mhz_maximum = Some(rounded_value);
-      }
+      delta.frequency_minimum = eval_frequency(
+        &self.frequency_mhz_minimum,
+        &state,
+        "cpu.frequency-mhz-minimum",
+      )?;
+      delta.frequency_maximum = eval_frequency(
+        &self.frequency_mhz_maximum,
+        &state,
+        "cpu.frequency-mhz-maximum",
+      )?;
 
       if let Some(pm_qos_resume_latency_us) = &self.pm_qos_resume_latency_us
         && let Some(pm_qos_resume_latency_us) =
@@ -719,6 +686,25 @@ fn eval_u32(
   }
 
   Ok(Some(value as u32))
+}
+
+fn eval_frequency(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<cpu::frequency::Frequency>> {
+  let Some(expression) = expression else {
+    return Ok(None);
+  };
+  let Some(value) = expression.eval(state)? else {
+    return Ok(None);
+  };
+  let value = value
+    .try_into_number()
+    .with_context(|| format!("`{name}` was not a number"))?;
+  cpu::frequency::Frequency::from_mhz(value)
+    .with_context(|| format!("invalid `{name}`"))
+    .map(Some)
 }
 
 fn eval_i32(
@@ -1578,7 +1564,7 @@ impl Expression {
       },
       FrequencyAvailable => {
         Boolean(match state.context {
-          EvalContext::Cpu(cpu) => cpu.frequency_mhz.is_some(),
+          EvalContext::Cpu(cpu) => cpu.frequency_available(),
           EvalContext::PowerSupply(_) => false,
           EvalContext::WidestPossible => state.frequency_available,
         })
@@ -1620,11 +1606,16 @@ impl Expression {
         Number(try_ok!(state.cpu_temperature_volatility))
       },
       CpuIdleSeconds => Number(state.cpu_idle_seconds),
-      CpuFrequencyMaximum => Number(try_ok!(state.cpu_frequency_maximum)),
+      CpuFrequencyMaximum => {
+        Number(try_ok!(match state.context {
+          EvalContext::Cpu(cpu) => cpu.frequency_maximum.map(|f| f.as_mhz()),
+          EvalContext::PowerSupply(_) => None,
+          EvalContext::WidestPossible => state.cpu_frequency_maximum,
+        }))
+      },
       CpuFrequencyMinimum => {
         Number(try_ok!(match state.context {
-          EvalContext::Cpu(cpu) =>
-            cpu.frequency_mhz_minimum.map(|mhz| mhz as f64),
+          EvalContext::Cpu(cpu) => cpu.frequency_minimum.map(|f| f.as_mhz()),
           EvalContext::PowerSupply(_) => None,
           EvalContext::WidestPossible => state.cpu_frequency_minimum,
         }))
@@ -1634,9 +1625,9 @@ impl Expression {
         let max = state
           .cpus
           .iter()
-          .filter_map(|cpu| cpu.frequency_mhz_maximum)
+          .filter_map(|cpu| cpu.frequency_maximum)
           .max()
-          .map(|v| v as f64);
+          .map(|frequency| frequency.as_mhz());
         Number(try_ok!(max))
       },
 
@@ -2008,6 +1999,11 @@ mod tests {
 
   use super::*;
 
+  fn frequency_mhz(mhz: u64) -> cpu::frequency::Frequency {
+    cpu::frequency::Frequency::from_mhz(mhz as f64)
+      .expect("valid test frequency")
+  }
+
   proptest! {
     #[test]
     fn test_multiply_float(
@@ -2020,11 +2016,12 @@ mod tests {
       let cpu = Arc::new(cpu::Cpu {
         number: 0,
         has_cpufreq: true,
+        frequency_control: true,
         available_governors: vec![],
         governor: None,
-        frequency_mhz: Some(base_freq),
-        frequency_mhz_minimum: Some(1000),
-        frequency_mhz_maximum: Some(base_freq),
+        frequency: Some(frequency_mhz(base_freq)),
+        frequency_minimum: Some(frequency_mhz(1000)),
+        frequency_maximum: Some(frequency_mhz(base_freq)),
         available_epps: vec![],
         epp: None,
         available_epbs: vec![],
@@ -2124,20 +2121,21 @@ mod tests {
   #[test]
   fn test_rounding() {
     let cpu = Arc::new(cpu::Cpu {
-      number:                0,
-      has_cpufreq:           true,
-      available_governors:   vec![],
-      governor:              None,
-      frequency_mhz:         Some(3333),
-      frequency_mhz_minimum: Some(1000),
-      frequency_mhz_maximum: Some(3333),
-      available_epps:        vec![],
-      epp:                   None,
-      available_epbs:        vec![],
-      epb:                   None,
-      stat:                  cpu::CpuStat::default(),
-      previous_stat:         None,
-      info:                  None,
+      number:              0,
+      has_cpufreq:         true,
+      frequency_control:   true,
+      available_governors: vec![],
+      governor:            None,
+      frequency:           Some(frequency_mhz(3333)),
+      frequency_minimum:   Some(frequency_mhz(1000)),
+      frequency_maximum:   Some(frequency_mhz(3333)),
+      available_epps:      vec![],
+      epp:                 None,
+      available_epbs:      vec![],
+      epb:                 None,
+      stat:                cpu::CpuStat::default(),
+      previous_stat:       None,
+      info:                None,
     });
 
     let mut cpus = HashSet::new();
@@ -2208,29 +2206,30 @@ mod tests {
 
     if let Ok((deltas, _)) = result {
       let delta = deltas.get(&cpu).unwrap();
-      assert!(delta.frequency_mhz_maximum.is_some());
-      let freq = delta.frequency_mhz_maximum.unwrap();
-      assert_eq!(freq, 2166); // should be rounded to 2166
+      assert!(delta.frequency_maximum.is_some());
+      let frequency = delta.frequency_maximum.unwrap();
+      assert_eq!(frequency.as_khz(), 2_166_450);
     }
   }
 
   #[test]
   fn test_volatility_expressions_with_insufficient_data() {
     let cpu = Arc::new(cpu::Cpu {
-      number:                0,
-      has_cpufreq:           true,
-      available_governors:   vec![],
-      governor:              None,
-      frequency_mhz:         Some(3333),
-      frequency_mhz_minimum: Some(1000),
-      frequency_mhz_maximum: Some(3333),
-      available_epps:        vec![],
-      epp:                   None,
-      available_epbs:        vec![],
-      epb:                   None,
-      stat:                  cpu::CpuStat::default(),
-      previous_stat:         None,
-      info:                  None,
+      number:              0,
+      has_cpufreq:         true,
+      frequency_control:   true,
+      available_governors: vec![],
+      governor:            None,
+      frequency:           Some(frequency_mhz(3333)),
+      frequency_minimum:   Some(frequency_mhz(1000)),
+      frequency_maximum:   Some(frequency_mhz(3333)),
+      available_epps:      vec![],
+      epp:                 None,
+      available_epbs:      vec![],
+      epb:                 None,
+      stat:                cpu::CpuStat::default(),
+      previous_stat:       None,
+      info:                None,
     });
 
     let mut cpus = HashSet::new();
@@ -2294,23 +2293,21 @@ mod tests {
   #[test]
   fn first_available_governor_selects_first_supported_value() {
     let cpu = Arc::new(cpu::Cpu {
-      number:                0,
-      has_cpufreq:           true,
-      available_governors:   vec![
-        "powersave".to_owned(),
-        "schedutil".to_owned(),
-      ],
-      governor:              None,
-      frequency_mhz:         Some(3333),
-      frequency_mhz_minimum: Some(1000),
-      frequency_mhz_maximum: Some(3333),
-      available_epps:        vec![],
-      epp:                   None,
-      available_epbs:        vec![],
-      epb:                   None,
-      stat:                  cpu::CpuStat::default(),
-      previous_stat:         None,
-      info:                  None,
+      number:              0,
+      has_cpufreq:         true,
+      frequency_control:   true,
+      available_governors: vec!["powersave".to_owned(), "schedutil".to_owned()],
+      governor:            None,
+      frequency:           Some(frequency_mhz(3333)),
+      frequency_minimum:   Some(frequency_mhz(1000)),
+      frequency_maximum:   Some(frequency_mhz(3333)),
+      available_epps:      vec![],
+      epp:                 None,
+      available_epbs:      vec![],
+      epb:                 None,
+      stat:                cpu::CpuStat::default(),
+      previous_stat:       None,
+      info:                None,
     });
 
     let mut cpus = HashSet::new();
@@ -2375,78 +2372,8 @@ mod tests {
 
     assert_eq!(result, None);
   }
-
-  #[test]
-  fn frequency_expressions_are_scoped_to_the_cpu_being_evaluated() {
-    let available_cpu = Arc::new(cpu::Cpu {
-      number: 0,
-      frequency_mhz: Some(1000),
-      frequency_mhz_minimum: Some(702),
-      ..cpu::Cpu::default()
-    });
-    let unavailable_cpu = Arc::new(cpu::Cpu {
-      number: 6,
-      frequency_mhz: None,
-      ..cpu::Cpu::default()
-    });
-    let cpus =
-      HashSet::from([Arc::clone(&available_cpu), Arc::clone(&unavailable_cpu)]);
-
-    let power_supplies = HashSet::new();
-    let uncores = HashSet::new();
-    let disks = HashSet::new();
-    let usb_devices = HashSet::new();
-    let gpus = HashSet::new();
-    let cpu_log = VecDeque::new();
-    let state = EvalState {
-      frequency_available:         true,
-      turbo_available:             false,
-      cpu_usage:                   0.0,
-      cpu_usage_volatility:        None,
-      cpu_temperature:             None,
-      cpu_temperature_volatility:  None,
-      cpu_idle_seconds:            0.0,
-      cpu_frequency_maximum:       None,
-      cpu_frequency_minimum:       None,
-      lid_closed:                  false,
-      virtual_machine:             false,
-      chassis_type:                None,
-      power_supply_charge:         None,
-      power_supply_discharge_rate: None,
-      battery_cycles:              None,
-      battery_health:              None,
-      discharging:                 false,
-      power_profile_preference:    crate::profile::PowerProfile::Balanced,
-      context:                     EvalContext::WidestPossible,
-      cpus:                        &cpus,
-      uncores:                     &uncores,
-      disks:                       &disks,
-      usb_devices:                 &usb_devices,
-      gpus:                        &gpus,
-      power_supplies:              &power_supplies,
-      cpu_log:                     &cpu_log,
-    };
-    let config = DaemonConfig::load_from(None).expect("load default config");
-    let cpu_delta = &config
-      .rules
-      .iter()
-      .find(|rule| rule.name == "battery-balanced")
-      .expect("default battery-balanced rule")
-      .cpu;
-
-    let (deltas, _) = cpu_delta.eval(&state).expect("evaluate CPU deltas");
-
-    assert_eq!(
-      deltas
-        .get(&available_cpu)
-        .and_then(|delta| delta.frequency_mhz_minimum),
-      Some(702)
-    );
-    assert_eq!(
-      deltas
-        .get(&unavailable_cpu)
-        .and_then(|delta| delta.frequency_mhz_minimum),
-      None
-    );
-  }
 }
+
+#[cfg(test)]
+#[path = "config/frequency_tests.rs"]
+mod frequency_tests;

--- a/watt/config/frequency_tests.rs
+++ b/watt/config/frequency_tests.rs
@@ -1,0 +1,87 @@
+use std::{
+  collections::{
+    HashSet,
+    VecDeque,
+  },
+  sync::Arc,
+};
+
+use super::*;
+
+fn frequency(mhz: f64) -> cpu::frequency::Frequency {
+  cpu::frequency::Frequency::from_mhz(mhz).expect("valid test frequency")
+}
+
+#[test]
+fn default_frequency_rule_uses_each_cpu_hardware_range() {
+  let available_cpu = Arc::new(cpu::Cpu {
+    number: 0,
+    frequency_control: true,
+    frequency: Some(frequency(1000.0)),
+    frequency_minimum: Some(frequency(702.4)),
+    frequency_maximum: Some(frequency(3504.0)),
+    ..cpu::Cpu::default()
+  });
+  let unavailable_cpu = Arc::new(cpu::Cpu {
+    number: 6,
+    ..cpu::Cpu::default()
+  });
+  let cpus =
+    HashSet::from([Arc::clone(&available_cpu), Arc::clone(&unavailable_cpu)]);
+  let power_supplies = HashSet::new();
+  let uncores = HashSet::new();
+  let disks = HashSet::new();
+  let usb_devices = HashSet::new();
+  let gpus = HashSet::new();
+  let cpu_log = VecDeque::new();
+  let state = EvalState {
+    frequency_available:         true,
+    turbo_available:             false,
+    cpu_usage:                   0.0,
+    cpu_usage_volatility:        None,
+    cpu_temperature:             None,
+    cpu_temperature_volatility:  None,
+    cpu_idle_seconds:            0.0,
+    cpu_frequency_maximum:       None,
+    cpu_frequency_minimum:       None,
+    lid_closed:                  false,
+    virtual_machine:             false,
+    chassis_type:                None,
+    power_supply_charge:         None,
+    power_supply_discharge_rate: None,
+    battery_cycles:              None,
+    battery_health:              None,
+    discharging:                 false,
+    power_profile_preference:    crate::profile::PowerProfile::Balanced,
+    context:                     EvalContext::WidestPossible,
+    cpus:                        &cpus,
+    uncores:                     &uncores,
+    disks:                       &disks,
+    usb_devices:                 &usb_devices,
+    gpus:                        &gpus,
+    power_supplies:              &power_supplies,
+    cpu_log:                     &cpu_log,
+  };
+  let config = DaemonConfig::load_from(None).expect("load default config");
+  let rule = config
+    .rules
+    .iter()
+    .find(|rule| rule.name == "battery-balanced")
+    .expect("default battery-balanced rule");
+
+  let (deltas, _) = rule.cpu.eval(&state).expect("evaluate CPU deltas");
+
+  assert_eq!(
+    deltas
+      .get(&available_cpu)
+      .and_then(|delta| delta.frequency_minimum)
+      .map(cpu::frequency::Frequency::as_khz),
+    Some(702_400)
+  );
+  assert_eq!(
+    deltas
+      .get(&unavailable_cpu)
+      .and_then(|delta| delta.frequency_minimum),
+    None
+  );
+}

--- a/watt/cpu.rs
+++ b/watt/cpu.rs
@@ -19,6 +19,10 @@ use yansi::Paint as _;
 
 use crate::fs;
 
+pub mod frequency;
+
+use frequency::Frequency;
+
 #[derive(Default, Debug, Clone, PartialEq)]
 struct CpuScanCache {
   stat: OnceCell<HashMap<u32, CpuStat>>,
@@ -71,14 +75,15 @@ impl CpuStat {
 pub struct Cpu {
   pub number: u32,
 
-  pub has_cpufreq: bool,
+  pub has_cpufreq:       bool,
+  pub frequency_control: bool,
 
   pub available_governors: Vec<String>,
   pub governor:            Option<String>,
 
-  pub frequency_mhz:         Option<u64>,
-  pub frequency_mhz_minimum: Option<u64>,
-  pub frequency_mhz_maximum: Option<u64>,
+  pub frequency:         Option<Frequency>,
+  pub frequency_minimum: Option<Frequency>,
+  pub frequency_maximum: Option<Frequency>,
 
   pub available_epps: Vec<String>,
   pub epp:            Option<String>,
@@ -194,6 +199,18 @@ impl Cpu {
 
     self.has_cpufreq =
       fs::exists(format!("/sys/devices/system/cpu/cpu{number}/cpufreq"));
+    self.frequency_control = [
+      "scaling_min_freq",
+      "scaling_max_freq",
+      "cpuinfo_min_freq",
+      "cpuinfo_max_freq",
+    ]
+    .iter()
+    .all(|name| {
+      fs::exists(format!(
+        "/sys/devices/system/cpu/cpu{number}/cpufreq/{name}"
+      ))
+    });
 
     log::trace!(
       "CPU {number} has cpufreq: {has_cpufreq}",
@@ -243,31 +260,6 @@ impl Cpu {
           .collect()
       };
     }
-
-    Ok(())
-  }
-
-  fn scan_frequency(&mut self) -> anyhow::Result<()> {
-    log::trace!("scanning frequency for CPU {number}", number = self.number);
-
-    let Self { number, .. } = *self;
-
-    let frequency_khz = fs::read_n::<u64>(format!(
-      "/sys/devices/system/cpu/cpu{number}/cpufreq/cpuinfo_cur_freq"
-    ))
-    .with_context(|| format!("failed to parse {self} frequency"))?;
-    let frequency_khz_minimum = fs::read_n::<u64>(format!(
-      "/sys/devices/system/cpu/cpu{number}/cpufreq/cpuinfo_min_freq"
-    ))
-    .with_context(|| format!("failed to parse {self} frequency minimum"))?;
-    let frequency_khz_maximum = fs::read_n::<u64>(format!(
-      "/sys/devices/system/cpu/cpu{number}/cpufreq/cpuinfo_max_freq"
-    ))
-    .with_context(|| format!("failed to parse {self} frequency maximum"))?;
-
-    self.frequency_mhz = frequency_khz.map(|x| x / 1000);
-    self.frequency_mhz_minimum = frequency_khz_minimum.map(|x| x / 1000);
-    self.frequency_mhz_maximum = frequency_khz_maximum.map(|x| x / 1000);
 
     Ok(())
   }
@@ -458,22 +450,8 @@ impl Cpu {
   }
 
   pub fn set_governor(&mut self, governor: &str) -> anyhow::Result<()> {
-    let Self {
-      number,
-      available_governors: ref governors,
-      ..
-    } = *self;
-
-    if !governors
-      .iter()
-      .any(|avail_governor| avail_governor == governor)
-    {
-      bail!(
-        "governor '{governor}' is not available for {self}. available \
-         governors: {governors}",
-        governors = governors.join(", "),
-      );
-    }
+    self.validate_governor(governor)?;
+    let number = self.number;
 
     fs::write(
       format!("/sys/devices/system/cpu/cpu{number}/cpufreq/scaling_governor"),
@@ -496,20 +474,25 @@ impl Cpu {
     Ok(())
   }
 
-  pub fn set_epp(&mut self, epp: &str) -> anyhow::Result<()> {
-    let Self {
-      number,
-      available_epps: ref epps,
-      ..
-    } = *self;
-
-    if !epps.iter().any(|avail_epp| avail_epp == epp) {
+  fn validate_governor(&self, governor: &str) -> anyhow::Result<()> {
+    if !self
+      .available_governors
+      .iter()
+      .any(|value| value == governor)
+    {
       bail!(
-        "EPP value '{epp}' is not available for {self}. available EPP values: \
-         {epps}",
-        epps = epps.join(", "),
+        "governor '{governor}' is not available for {self}. available \
+         governors: {governors}",
+        governors = self.available_governors.join(", "),
       );
     }
+
+    Ok(())
+  }
+
+  pub fn set_epp(&mut self, epp: &str) -> anyhow::Result<()> {
+    self.validate_epp(epp)?;
+    let number = self.number;
 
     fs::write(
       format!(
@@ -532,20 +515,21 @@ impl Cpu {
     Ok(())
   }
 
-  pub fn set_epb(&mut self, epb: &str) -> anyhow::Result<()> {
-    let Self {
-      number,
-      available_epbs: ref epbs,
-      ..
-    } = *self;
-
-    if !epbs.iter().any(|avail_epb| avail_epb == epb) {
+  fn validate_epp(&self, epp: &str) -> anyhow::Result<()> {
+    if !self.available_epps.iter().any(|value| value == epp) {
       bail!(
-        "EPB value '{epb}' is not available for {self}. available EPB values: \
-         {valid}",
-        valid = epbs.join(", "),
+        "EPP value '{epp}' is not available for {self}. available EPP values: \
+         {epps}",
+        epps = self.available_epps.join(", "),
       );
     }
+
+    Ok(())
+  }
+
+  pub fn set_epb(&mut self, epb: &str) -> anyhow::Result<()> {
+    self.validate_epb(epb)?;
+    let number = self.number;
 
     fs::write(
       format!("/sys/devices/system/cpu/cpu{number}/power/energy_perf_bias"),
@@ -565,116 +549,12 @@ impl Cpu {
     Ok(())
   }
 
-  pub fn set_frequency_mhz_minimum(
-    &self,
-    frequency_mhz: u64,
-  ) -> anyhow::Result<()> {
-    let Self { number, .. } = *self;
-
-    self.validate_frequency_mhz_minimum(frequency_mhz)?;
-
-    // We use u64 for the intermediate calculation to prevent overflow
-    let frequency_khz = frequency_mhz * 1000;
-    let frequency_khz = frequency_khz.to_string();
-
-    fs::write(
-      format!("/sys/devices/system/cpu/cpu{number}/cpufreq/scaling_min_freq"),
-      &frequency_khz,
-    )
-    .with_context(|| {
-      format!(
-        "this probably means that {self} doesn't exist or doesn't support \
-         changing minimum frequency"
-      )
-    })?;
-
-    log::info!(
-      "CPU {number} min frequency set to {frequency_mhz} MHz",
-      number = self.number,
-    );
-
-    Ok(())
-  }
-
-  fn validate_frequency_mhz_minimum(
-    &self,
-    new_frequency_mhz: u64,
-  ) -> anyhow::Result<()> {
-    let Self { number, .. } = self;
-
-    let Some(minimum_frequency_khz) = fs::read_n::<u64>(format!(
-      "/sys/devices/system/cpu/cpu{number}/cpufreq/cpuinfo_min_freq"
-    ))
-    .with_context(|| format!("failed to read {self} minimum frequency"))?
-    else {
-      // Just let it pass if we can't find anything.
-      return Ok(());
-    };
-
-    if new_frequency_mhz * 1000 < minimum_frequency_khz {
+  fn validate_epb(&self, epb: &str) -> anyhow::Result<()> {
+    if !self.available_epbs.iter().any(|value| value == epb) {
       bail!(
-        "new software minimum frequency ({new_frequency_mhz} MHz) cannot be \
-         lower than the hardware minimum frequency ({mhz} MHz) for {self}",
-        mhz = minimum_frequency_khz / 1000,
-      );
-    }
-
-    Ok(())
-  }
-
-  pub fn set_frequency_mhz_maximum(
-    &self,
-    frequency_mhz: u64,
-  ) -> anyhow::Result<()> {
-    let Self { number, .. } = *self;
-
-    self.validate_frequency_mhz_maximum(frequency_mhz)?;
-
-    // We use u64 for the intermediate calculation to prevent overflow
-    let frequency_khz = frequency_mhz * 1000;
-    let frequency_khz = frequency_khz.to_string();
-
-    fs::write(
-      format!("/sys/devices/system/cpu/cpu{number}/cpufreq/scaling_max_freq"),
-      &frequency_khz,
-    )
-    .with_context(|| {
-      format!(
-        "this probably means that {self} doesn't exist or doesn't support \
-         changing maximum frequency"
-      )
-    })?;
-
-    log::info!(
-      "CPU {number} max frequency set to {frequency_mhz} MHz",
-      number = self.number,
-    );
-
-    Ok(())
-  }
-
-  fn validate_frequency_mhz_maximum(
-    &self,
-    new_frequency_mhz: u64,
-  ) -> anyhow::Result<()> {
-    let Self { number, .. } = self;
-
-    let Some(maximum_frequency_khz) = fs::read_n::<u64>(format!(
-      "/sys/devices/system/cpu/cpu{number}/cpufreq/cpuinfo_max_freq"
-    ))
-    .with_context(|| {
-      format!("failed to read {self} hardware maximum frequency")
-    })?
-    else {
-      // Just let it pass if we can't find anything.
-      return Ok(());
-    };
-
-    if new_frequency_mhz * 1000 > maximum_frequency_khz {
-      bail!(
-        "new software maximum frequency ({new_frequency_mhz} MHz) cannot be \
-         higher than the hardware maximum frequency ({mhz} MHz) for {self}",
-        mhz = maximum_frequency_khz / 1000,
+        "EPB value '{epb}' is not available for {self}. available EPB values: \
+         {valid}",
+        valid = self.available_epbs.join(", "),
       );
     }
 
@@ -685,6 +565,7 @@ impl Cpu {
     &self,
     latency: &str,
   ) -> anyhow::Result<()> {
+    self.validate_pm_qos_resume_latency()?;
     let Self { number, .. } = *self;
 
     fs::write(
@@ -704,6 +585,17 @@ impl Cpu {
       "CPU {number} PM QoS resume latency set to {latency} us",
       number = self.number,
     );
+
+    Ok(())
+  }
+
+  fn validate_pm_qos_resume_latency(&self) -> anyhow::Result<()> {
+    let number = self.number;
+    if !fs::exists(format!(
+      "/sys/devices/system/cpu/cpu{number}/power/pm_qos_resume_latency_us"
+    )) {
+      bail!("PM QoS resume latency is not available for {self}");
+    }
 
     Ok(())
   }
@@ -788,20 +680,6 @@ impl Cpu {
     bail!("no supported CPU boost control mechanism found");
   }
 
-  pub fn hardware_frequency_mhz_maximum() -> anyhow::Result<Option<u64>> {
-    log::trace!("reading hardware frequency limits");
-
-    fs::read_n::<u64>("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")
-      .context("failed to read CPU hardware maximum frequency")
-      .map(|x| x.map(|freq| freq / 1000))
-  }
-
-  pub fn hardware_frequency_mhz_minimum() -> anyhow::Result<Option<u64>> {
-    fs::read_n::<u64>("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq")
-      .context("failed to read CPU hardware minimum frequency")
-      .map(|x| x.map(|freq| freq / 1000))
-  }
-
   pub fn is_intel_pstate() -> bool {
     fs::exists("/sys/devices/system/cpu/intel_pstate")
   }
@@ -833,8 +711,8 @@ pub struct Delta {
   pub governor:                      Option<String>,
   pub energy_performance_preference: Option<String>,
   pub energy_perf_bias:              Option<String>,
-  pub frequency_mhz_minimum:         Option<u64>,
-  pub frequency_mhz_maximum:         Option<u64>,
+  pub frequency_minimum:             Option<Frequency>,
+  pub frequency_maximum:             Option<Frequency>,
   pub pm_qos_resume_latency_us:      Option<String>,
 }
 
@@ -843,8 +721,8 @@ impl Delta {
     self.governor.is_some()
       && self.energy_performance_preference.is_some()
       && self.energy_perf_bias.is_some()
-      && self.frequency_mhz_minimum.is_some()
-      && self.frequency_mhz_maximum.is_some()
+      && self.frequency_minimum.is_some()
+      && self.frequency_maximum.is_some()
       && self.pm_qos_resume_latency_us.is_some()
   }
 
@@ -859,19 +737,41 @@ impl Delta {
       energy_perf_bias:              self
         .energy_perf_bias
         .or_else(|| that.energy_perf_bias.clone()),
-      frequency_mhz_minimum:         self
-        .frequency_mhz_minimum
-        .or(that.frequency_mhz_minimum),
-      frequency_mhz_maximum:         self
-        .frequency_mhz_maximum
-        .or(that.frequency_mhz_maximum),
+      frequency_minimum:             self
+        .frequency_minimum
+        .or(that.frequency_minimum),
+      frequency_maximum:             self
+        .frequency_maximum
+        .or(that.frequency_maximum),
       pm_qos_resume_latency_us:      self
         .pm_qos_resume_latency_us
         .or_else(|| that.pm_qos_resume_latency_us.clone()),
     }
   }
 
+  pub fn validate(&self, cpu: &Cpu) -> anyhow::Result<()> {
+    if let Some(governor) = &self.governor {
+      cpu.validate_governor(governor)?;
+    }
+    if let Some(epp) = &self.energy_performance_preference {
+      cpu.validate_epp(epp)?;
+    }
+    if let Some(epb) = &self.energy_perf_bias {
+      cpu.validate_epb(epb)?;
+    }
+    if self.pm_qos_resume_latency_us.is_some() {
+      cpu.validate_pm_qos_resume_latency()?;
+    }
+
+    cpu
+      .frequency_transition(self.frequency_minimum, self.frequency_maximum)
+      .map(|_| ())
+  }
+
   pub fn apply(&self, cpu: &mut Cpu) -> anyhow::Result<()> {
+    let frequency = cpu
+      .frequency_transition(self.frequency_minimum, self.frequency_maximum)?;
+
     if let Some(governor) = &self.governor {
       cpu.set_governor(governor)?;
     }
@@ -884,12 +784,8 @@ impl Delta {
       cpu.set_epb(epb)?;
     }
 
-    if let Some(mhz_minimum) = self.frequency_mhz_minimum {
-      cpu.set_frequency_mhz_minimum(mhz_minimum)?;
-    }
-
-    if let Some(mhz_maximum) = self.frequency_mhz_maximum {
-      cpu.set_frequency_mhz_maximum(mhz_maximum)?;
+    if let Some(frequency) = frequency {
+      cpu.apply_frequency_transition(frequency)?;
     }
 
     if let Some(latency) = &self.pm_qos_resume_latency_us {

--- a/watt/cpu/frequency.rs
+++ b/watt/cpu/frequency.rs
@@ -1,0 +1,311 @@
+use std::fmt;
+
+use anyhow::{
+  Context,
+  bail,
+};
+
+use super::Cpu;
+use crate::fs;
+
+const KHZ_PER_MHZ: f64 = 1000.0;
+
+/// A positive CPU frequency stored exactly in kHz.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Frequency(u64);
+
+impl Frequency {
+  /// Constructs a frequency from a positive kHz value.
+  pub fn from_khz(khz: u64) -> anyhow::Result<Self> {
+    if khz == 0 {
+      bail!("frequency must be greater than zero");
+    }
+
+    Ok(Self(khz))
+  }
+
+  /// Constructs a frequency from MHz, rounded to the nearest kHz.
+  pub fn from_mhz(mhz: f64) -> anyhow::Result<Self> {
+    let khz = (mhz * KHZ_PER_MHZ).round();
+    if !khz.is_finite() || khz < 1.0 || khz >= u64::MAX as f64 {
+      bail!("invalid frequency: {mhz} MHz");
+    }
+
+    Ok(Self(khz as u64))
+  }
+
+  /// Returns the exact frequency in kHz.
+  pub const fn as_khz(self) -> u64 {
+    self.0
+  }
+
+  /// Returns the frequency represented in MHz.
+  pub fn as_mhz(self) -> f64 {
+    self.0 as f64 / KHZ_PER_MHZ
+  }
+}
+
+impl fmt::Display for Frequency {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(formatter, "{} kHz", self.0)
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Range {
+  minimum: Frequency,
+  maximum: Frequency,
+}
+
+impl Range {
+  fn new(minimum: Frequency, maximum: Frequency) -> anyhow::Result<Self> {
+    if minimum > maximum {
+      bail!(
+        "minimum frequency ({minimum}) cannot be higher than maximum \
+         frequency ({maximum})"
+      );
+    }
+
+    Ok(Self { minimum, maximum })
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct Transition {
+  minimum: Option<Frequency>,
+  maximum: Option<Frequency>,
+  order:   WriteOrder,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WriteOrder {
+  MinimumFirst,
+  MaximumFirst,
+}
+
+impl Transition {
+  fn new(
+    hardware: Range,
+    current: Range,
+    minimum: Option<Frequency>,
+    maximum: Option<Frequency>,
+  ) -> anyhow::Result<Self> {
+    let target = Range::new(
+      minimum.unwrap_or(current.minimum),
+      maximum.unwrap_or(current.maximum),
+    )?;
+
+    if target.minimum < hardware.minimum {
+      bail!(
+        "new software minimum frequency ({minimum}) cannot be lower than the \
+         hardware minimum frequency ({hardware_minimum})",
+        minimum = target.minimum,
+        hardware_minimum = hardware.minimum,
+      );
+    }
+    if target.maximum > hardware.maximum {
+      bail!(
+        "new software maximum frequency ({maximum}) cannot be higher than the \
+         hardware maximum frequency ({hardware_maximum})",
+        maximum = target.maximum,
+        hardware_maximum = hardware.maximum,
+      );
+    }
+
+    Ok(Self {
+      minimum,
+      maximum,
+      order: if target.minimum > current.maximum {
+        WriteOrder::MaximumFirst
+      } else {
+        WriteOrder::MinimumFirst
+      },
+    })
+  }
+}
+
+impl Cpu {
+  pub(super) fn scan_frequency(&mut self) -> anyhow::Result<()> {
+    let number = self.number;
+    let path =
+      |name| format!("/sys/devices/system/cpu/cpu{number}/cpufreq/{name}");
+
+    self.frequency = read(path("cpuinfo_cur_freq"))
+      .with_context(|| format!("failed to parse {self} frequency"))?;
+    if self.frequency.is_none() {
+      self.frequency = read(path("scaling_cur_freq"))
+        .with_context(|| format!("failed to parse {self} frequency"))?;
+    }
+    self.frequency_minimum = read(path("cpuinfo_min_freq"))
+      .with_context(|| format!("failed to parse {self} frequency minimum"))?;
+    self.frequency_maximum = read(path("cpuinfo_max_freq"))
+      .with_context(|| format!("failed to parse {self} frequency maximum"))?;
+
+    Ok(())
+  }
+
+  pub fn frequency_available(&self) -> bool {
+    self.frequency_control
+      && self.frequency_minimum.is_some()
+      && self.frequency_maximum.is_some()
+  }
+
+  pub(super) fn frequency_transition(
+    &self,
+    minimum: Option<Frequency>,
+    maximum: Option<Frequency>,
+  ) -> anyhow::Result<Option<Transition>> {
+    if minimum.is_none() && maximum.is_none() {
+      return Ok(None);
+    }
+
+    let hardware = Range::new(
+      self
+        .frequency_minimum
+        .context("hardware minimum frequency is unavailable")?,
+      self
+        .frequency_maximum
+        .context("hardware maximum frequency is unavailable")?,
+    )
+    .with_context(|| format!("invalid hardware frequency range for {self}"))?;
+    let current = Range::new(
+      self.read_frequency("scaling_min_freq")?,
+      self.read_frequency("scaling_max_freq")?,
+    )
+    .with_context(|| format!("invalid current frequency range for {self}"))?;
+
+    Transition::new(hardware, current, minimum, maximum)
+      .with_context(|| format!("invalid requested frequency range for {self}"))
+      .map(Some)
+  }
+
+  pub(super) fn apply_frequency_transition(
+    &self,
+    transition: Transition,
+  ) -> anyhow::Result<()> {
+    let Transition {
+      minimum,
+      maximum,
+      order,
+    } = transition;
+
+    let writes = match order {
+      WriteOrder::MinimumFirst => {
+        [("scaling_min_freq", minimum), ("scaling_max_freq", maximum)]
+      },
+      WriteOrder::MaximumFirst => {
+        [("scaling_max_freq", maximum), ("scaling_min_freq", minimum)]
+      },
+    };
+    for (name, frequency) in writes {
+      if let Some(frequency) = frequency {
+        self.write_frequency(name, frequency)?;
+      }
+    }
+
+    Ok(())
+  }
+
+  fn read_frequency(&self, name: &str) -> anyhow::Result<Frequency> {
+    let path =
+      format!("/sys/devices/system/cpu/cpu{}/cpufreq/{name}", self.number);
+
+    read(path)?.with_context(|| format!("{name} is unavailable for {self}"))
+  }
+
+  fn write_frequency(
+    &self,
+    name: &str,
+    frequency: Frequency,
+  ) -> anyhow::Result<()> {
+    let path =
+      format!("/sys/devices/system/cpu/cpu{}/cpufreq/{name}", self.number);
+
+    fs::write(path, &frequency.as_khz().to_string())
+      .with_context(|| format!("failed to set {name} for {self}"))?;
+    log::info!("{self} {name} set to {frequency}");
+
+    Ok(())
+  }
+}
+
+fn read(
+  path: impl AsRef<std::path::Path>,
+) -> anyhow::Result<Option<Frequency>> {
+  fs::read_n::<u64>(path)?
+    .map(Frequency::from_khz)
+    .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn frequency(khz: u64) -> Frequency {
+    Frequency::from_khz(khz).expect("valid test frequency")
+  }
+
+  #[test]
+  fn frequency_rejects_invalid_mhz() {
+    for mhz in [-1.0, 0.0, f64::INFINITY, u64::MAX as f64] {
+      assert!(Frequency::from_mhz(mhz).is_err(), "{mhz} must be rejected");
+    }
+  }
+
+  #[test]
+  fn frequency_preserves_fractional_mhz_as_exact_khz() {
+    assert_eq!(
+      Frequency::from_mhz(702.4)
+        .expect("valid frequency")
+        .as_khz(),
+      702_400
+    );
+  }
+
+  #[test]
+  fn transition_raises_maximum_before_minimum() {
+    let transition = Transition::new(
+      Range::new(frequency(400_000), frequency(4_000_000)).unwrap(),
+      Range::new(frequency(400_000), frequency(1_000_000)).unwrap(),
+      Some(frequency(2_000_000)),
+      Some(frequency(3_000_000)),
+    )
+    .expect("valid transition");
+
+    assert_eq!(transition.order, WriteOrder::MaximumFirst);
+  }
+
+  #[test]
+  fn transition_lowers_minimum_before_maximum() {
+    let transition = Transition::new(
+      Range::new(frequency(400_000), frequency(4_000_000)).unwrap(),
+      Range::new(frequency(2_000_000), frequency(4_000_000)).unwrap(),
+      Some(frequency(1_000_000)),
+      Some(frequency(1_500_000)),
+    )
+    .expect("valid transition");
+
+    assert_eq!(transition.order, WriteOrder::MinimumFirst);
+  }
+
+  #[test]
+  fn transition_rejects_inverted_or_out_of_hardware_range() {
+    let hardware =
+      Range::new(frequency(702_000), frequency(3_504_000)).unwrap();
+    let current = Range::new(frequency(702_000), frequency(3_504_000)).unwrap();
+
+    assert!(
+      Transition::new(
+        hardware,
+        current,
+        Some(frequency(2_000_000)),
+        Some(frequency(1_800_000)),
+      )
+      .is_err()
+    );
+    assert!(
+      Transition::new(hardware, current, Some(frequency(200_000)), None,)
+        .is_err()
+    );
+  }
+}

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -1184,7 +1184,7 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
         frequency_available: system
           .cpus
           .iter()
-          .any(|cpu| cpu.frequency_mhz.is_some()),
+          .any(|cpu| cpu.frequency_available()),
         turbo_available: cpu::Cpu::turbo()
           .context(
             "failed to read CPU turbo boost status for `is-turbo-available`",
@@ -1198,12 +1198,18 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           .cpu_volatility()
           .and_then(|vol| vol.temperature),
         cpu_idle_seconds: last_user_activity.elapsed().as_secs_f64(),
-        cpu_frequency_maximum: cpu::Cpu::hardware_frequency_mhz_maximum()
-          .context("failed to read CPU hardware maximum frequency")?
-          .map(|u64| u64 as f64),
-        cpu_frequency_minimum: cpu::Cpu::hardware_frequency_mhz_minimum()
-          .context("failed to read CPU hardware minimum frequency")?
-          .map(|u64| u64 as f64),
+        cpu_frequency_maximum: system
+          .cpus
+          .iter()
+          .filter_map(|cpu| cpu.frequency_maximum)
+          .max()
+          .map(|frequency| frequency.as_mhz()),
+        cpu_frequency_minimum: system
+          .cpus
+          .iter()
+          .filter_map(|cpu| cpu.frequency_minimum)
+          .min()
+          .map(|frequency| frequency.as_mhz()),
 
         lid_closed: system.lid_closed,
         virtual_machine: system.virtual_machine,
@@ -1388,6 +1394,12 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
             break;
           }
         }
+      }
+
+      for (cpu, delta) in &cpu_deltas {
+        delta
+          .validate(cpu)
+          .with_context(|| format!("failed to validate delta for {cpu}"))?;
       }
 
       for (cpu, delta) in &cpu_deltas {


### PR DESCRIPTION

I've changed CPU freq information and its representation from simple MHz values to a dedicated `Frequency` type with proper kHz precision. This is for the sake of improved validation and even nicer modularity for CPU property setters. Entails moving certain frequency related tests into a dedicated module for my future sanity. Most functions (e.g., `frequency_mhz` and `frequency_mhz_{minimum,maximum}` now use the new  type. Precision baby.

Change-Id: I9baf3d891ffafe4c3ece421cfe0022ae6a6a6964